### PR TITLE
Support for partial match searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,27 @@ Will return:
     state_ansi: 'IL',
     timezone: 'America/Chicago' } ]
 ```
+
+### cityTimezones.lookupViaPartialMatch(searchString: string)
+
+This method will return any partial match for the search term based on city, province, or country, or a combination thereof. A U.S. based city will also return matches for the `state_ansi` property.
+
+finding based on search term of Springfield MO
+```javascript
+const cityLookup = cityTimezones.lookupViaPartialMatch('springfield mo')
+console.log(cityLookup)
+```
+Will return:
+```javascript
+[ { city: 'Springfield',
+    city_ascii: 'Springfield',
+    lat: 37.18001609,
+    lng: -93.31999923,
+    pop: 180691,
+    country: 'United States of America',
+    iso2: 'US',
+    iso3: 'USA',
+    province: 'Missouri',
+    state_ansi: 'MO',
+    timezone: 'America/Chicago' } ]	
+```

--- a/index.js
+++ b/index.js
@@ -11,6 +11,25 @@ function lookupViaCity(city) {
   }
 }
 
+function findPartialMatch(itemsToSearch, searchString) {
+    var searchItems = searchString.split(" ");
+    var isPartialMatch = searchItems.every(function(i) {
+        return itemsToSearch.join().toLowerCase().indexOf(i.toLowerCase()) >= 0;
+    })
+    return isPartialMatch;
+}
+
+function lookupViaPartialMatch(searchString) {
+  var searchItems = searchString.split(" ");
+  const cityLookup = _.filter(cityMapping, function (o) { return findPartialMatch([o.city,o.province,o.country], searchString) })
+  if (cityLookup && cityLookup.length > 0) {
+    return cityLookup
+  } else {
+    return []
+  }
+}
+
 module.exports = {
-  lookupViaCity
+  lookupViaCity,
+  lookupViaPartialMatch
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function findPartialMatch(itemsToSearch, searchString) {
 
 function lookupViaPartialMatch(searchString) {
   var searchItems = searchString.split(" ");
-  const cityLookup = _.filter(cityMapping, function (o) { return findPartialMatch([o.city,o.province,o.country], searchString) })
+  const cityLookup = _.filter(cityMapping, function (o) { return findPartialMatch([o.city,o.state_ansi,o.province,o.country], searchString) })
   if (cityLookup && cityLookup.length > 0) {
     return cityLookup
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "city-timezones",
+  "version": "1.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Kevin Roberts",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "mocha": "^3.2.0"


### PR DESCRIPTION
I'd been looking for this exact library, but I need to perform partial matches to provide some auto-complete functionality for end users typing in search terms. This PR adds functionality to return partial matches, e.g. "Sydney Australia" or "Springfield MO".

Happy to change the style / naming conventions or incorporate any other feedback. This feature is a must have for me, so I'd love to incorporate it into your library. 