### PR TITLE
Fix Oak Park definition

### DIFF
--- a/data/cityMap.json
+++ b/data/cityMap.json
@@ -88686,6 +88686,7 @@
     "iso2": "US",
     "iso3": "USA",
     "state_ansi": "IL",
+    "province": "Illinois",
     "timezone": "America/Chicago"
   }
 ]


### PR DESCRIPTION
It was missing "province" which caused issues when importing the json file into Swift.