### PR TITLE
[FIX] Using 'Argentina' as input for findFromCityStateProvince returns Chile timezone

### DIFF
--- a/data/cityMap.json
+++ b/data/cityMap.json
@@ -2445,7 +2445,7 @@
     "iso2": "AR",
     "iso3": "ARG",
     "province": "Santa Cruz",
-    "timezone": "America/Santiago"
+    "timezone": "America/Argentina/Rio_Gallegos"
   },
   {
     "city": "Gobernador Gregores",


### PR DESCRIPTION
First object in `cityMap.json` with country `Argentina` is of the city `28 de Noviembre`, and has its timezone set to `America/Santiago`. 

This is causing issues when using only the query `Argentina` in the method `findFromCityStateProvince`, given that this returns the timezone for Santiago, Chile. Not only this, but also the timezone is wrong for the argentinian city. All of the cities in Argentina share the same timezone, GMT-3. https://es.timeservers.net/cities/ar/28-de-noviembre